### PR TITLE
Make callbacks optional

### DIFF
--- a/src/uploader.js
+++ b/src/uploader.js
@@ -99,7 +99,9 @@ function uiUploader($log) {
             //console.info(event.loaded);
             file.loaded = event.loaded;
             file.humanSize = getHumanSize(event.loaded);
-            self.options.onProgress(file);
+            if (isFunction(self.options.onProgress)) {
+                self.options.onProgress(file);
+            }
         };
 
         // Triggered when upload is completed:
@@ -107,10 +109,14 @@ function uiUploader($log) {
             self.activeUploads -= 1;
             self.uploadedFiles += 1;
             startUpload(self.options);
-            self.options.onCompleted(file, xhr.responseText, xhr.status);
+            if (isFunction(self.options.onCompleted)) {
+                self.options.onCompleted(file, xhr.responseText, xhr.status);
+            }            
             if (self.uploadedFiles === self.files.length) {
                 self.uploadedFiles = 0;
-                self.options.onCompletedAll(self.files);
+                if (isFunction(self.options.onCompletedAll)) {
+                    self.options.onCompletedAll(self.files);
+                }
             }
         };
 


### PR DESCRIPTION
Currently callbacks are blindly called without checking if they actually exist -- making all callback functions mandatory. Not every application would need to use all the callbacks.
