### PR TITLE
Update on uploader.js

### DIFF
--- a/dist/uploader.js
+++ b/dist/uploader.js
@@ -130,7 +130,7 @@ function uiUploader($log) {
             if (angular.isFunction(self.options.onCompleted)) {
                 self.options.onCompleted(file, xhr.responseText, xhr.status);
             }            
-            if (self.uploadedFiles === self.files.length) {
+            if (self.activeUploads === 0) {
                 self.uploadedFiles = 0;
                 if (angular.isFunction(self.options.onCompletedAll)) {
                     self.options.onCompletedAll(self.files);


### PR DESCRIPTION
From my POV 'onCompletedAll' event should be triggered everytime all uploads finish. 
Let me explain the issue (test case):
- If I would make for example 'x' (variable) uploads (the event 'onCompletedAll' would be triggered). 
- The next time I would upload 'x' (variable) uploads (without clearing the previous uploads), the event 'onCompletedAll' would not be triggered (which I think is a wrong behaviour).
