### PR TITLE
Update on src/uploader.js

### DIFF
--- a/src/uploader.js
+++ b/src/uploader.js
@@ -120,7 +120,7 @@ function uiUploader($log) {
             if (angular.isFunction(self.options.onCompleted)) {
                 self.options.onCompleted(file, xhr.responseText, xhr.status);
             }            
-            if (self.uploadedFiles === self.files.length) {
+            if (self.activeUploads === 0) {
                 self.uploadedFiles = 0;
                 if (angular.isFunction(self.options.onCompletedAll)) {
                     self.options.onCompletedAll(self.files);


### PR DESCRIPTION
From my POV 'onCompletedAll' event should be triggered everytime all uploads finish. 
Let me explain the issue (test case):
- If I would make for example 'x' (variable) uploads (the event 'onCompletedAll' would be triggered). 
- The next time I would upload 'x' (variable) uploads (without clearing the previous uploads), the event 'onCompletedAll' would not be triggered.
