### PR TITLE
Corrected behaviour of withCredentials to work when passed in options

### DIFF
--- a/src/uploader.js
+++ b/src/uploader.js
@@ -34,6 +34,7 @@ function uiUploader($log) {
 
         //headers are not shared by requests
         var headers = options.headers || {};
+        var xhrOptions = options.options || {};
 
         for (var i = 0; i < self.files.length; i++) {
             if (self.activeUploads == self.options.concurrency) {
@@ -41,7 +42,7 @@ function uiUploader($log) {
             }
             if (self.files[i].active)
                 continue;
-            ajaxUpload(self.files[i], self.options.url, self.options.data, self.options.paramName, headers);
+            ajaxUpload(self.files[i], self.options.url, self.options.data, self.options.paramName, headers, xhrOptions);
         }
     }
 
@@ -68,7 +69,7 @@ function uiUploader($log) {
         return (bytes / Math.pow(1024, i)).toFixed(i ? 1 : 0) + ' ' + sizes[isNaN(bytes) ? 0 : i + 1];
     }
 
-    function ajaxUpload(file, url, data, key, headers) {
+    function ajaxUpload(file, url, data, key, headers, xhrOptions) {
         var xhr, formData, prop;
         data = data || {};
         key = key || 'file';
@@ -78,7 +79,7 @@ function uiUploader($log) {
         xhr = new window.XMLHttpRequest();
 
         // To account for sites that may require CORS
-        if (data.withCredentials === true) {
+        if (xhrOptions.withCredentials === true) {
             xhr.withCredentials = true;
         }
 


### PR DESCRIPTION
As per issue #30 , the `withCredentials` XHR options was not being respected as per the README. This has been corrected.